### PR TITLE
Add APIs for Update, Reply, Like, Document Upload, and Item Record Creation

### DIFF
--- a/app/Http/Controllers/Incorpify/DashboardController.php
+++ b/app/Http/Controllers/Incorpify/DashboardController.php
@@ -359,16 +359,6 @@ class DashboardController extends Controller
 
 
         $payload = $request->all();
-
-        echo '<pre>';
-        print_r($payload);
-        echo '[Line]:     ' . __LINE__ . "\n";
-        echo '[Function]: ' . __FUNCTION__ . "\n";
-        echo '[Class]:    ' . (__CLASS__ ? __CLASS__ : 'N/A') . "\n";
-        echo '[Method]:   ' . (__METHOD__ ? __METHOD__ : 'N/A') . "\n";
-        echo '[File]:     ' . __FILE__ . "\n";
-        die;
-        
         
         $column_id = "files";
 

--- a/app/Http/Controllers/Incorpify/DashboardController.php
+++ b/app/Http/Controllers/Incorpify/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Incorpify;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Traits\MondayApis;
+use Illuminate\Support\Facades\Validator;
 
 class DashboardController extends Controller
 {
@@ -190,4 +191,41 @@ class DashboardController extends Controller
             }';
        return $boardsData = $this->_getMondayData($query);
     }
+
+    public function update(Request $request){
+        
+        $payload = $request->json()->all();
+
+        //validate the request
+        $validator = Validator::make($request->all(), [
+            'item_id' => 'required|filled',
+            'text_body' => 'required|filled',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+
+        $query = [];
+        if(!empty($payload['parent_id'])){
+            $query = '{mutation {
+                create_update(item_id: '.$payload['item_id'].' parent_id: '.$payload['parent_id'].' body: "'.$payload['text_body'].'") {
+                  id
+                  body
+                }
+            }}';        
+        } else {
+            $query = 'mutation {
+                create_update(item_id: '.$payload['item_id'].' body: "'.$payload['text_body'].'") {
+                  id
+                  body
+                }
+            }';
+        }
+
+        //run the prepared graphQL query
+        return $this->_getMondayData($query);
+    }
+
 }

--- a/app/Http/Controllers/Incorpify/DashboardController.php
+++ b/app/Http/Controllers/Incorpify/DashboardController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Traits\MondayApis;
 use Illuminate\Support\Facades\Validator;
+use CURLFile;
 
 class DashboardController extends Controller
 {
@@ -335,11 +336,6 @@ class DashboardController extends Controller
             }
           }
         ';
-
-        // echo '<pre>';
-        //  print_r($query);
-        //  die;
-        
         
         $response = $this->_getMondayData($query);
         $subitems = $response['response']['data']['boards'][0]['items_page']['items'][0]['subitems'];
@@ -357,6 +353,93 @@ class DashboardController extends Controller
 
         $response['response']['data']['boards'][0]['items_page']['items'][0]['subitems'] = $send_response;
         return $response;
+    }
+
+    public function uploadFiles(Request $request) { 
+
+
+        $payload = $request->all();
+
+        echo '<pre>';
+        print_r($payload);
+        echo '[Line]:     ' . __LINE__ . "\n";
+        echo '[Function]: ' . __FUNCTION__ . "\n";
+        echo '[Class]:    ' . (__CLASS__ ? __CLASS__ : 'N/A') . "\n";
+        echo '[Method]:   ' . (__METHOD__ ? __METHOD__ : 'N/A') . "\n";
+        echo '[File]:     ' . __FILE__ . "\n";
+        die;
+        
+        
+        $column_id = "files";
+
+        // The ID of the item to which the file will be uploaded
+        $itemId = '1873224195';
+        
+        // The file you want to upload
+        $filePath = '/home/cedcoss/Desktop/notes.gif';
+        $fileMimeType = mime_content_type($filePath);
+        $fileName = basename($filePath);
+        
+        // The GraphQL query
+        $query = 'mutation ($file: File!) {
+        add_file_to_column (item_id: ' . $itemId . ' column_id: "'.$column_id.'", file: $file) {
+            id
+        }
+        }';
+        
+        // Prepare the variables
+        $variables = [
+            'file' => new CURLFile($filePath, $fileMimeType, $fileName)
+        ];
+        
+        // Initialize cURL
+        $ch = curl_init();
+        
+        // Set the cURL options
+        curl_setopt($ch, CURLOPT_URL, 'https://api.monday.com/v2/file');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Authorization: ' . env('MONDAY_API_KEY'),
+            'Content-Type: multipart/form-data'
+        ]);
+        
+        curl_setopt($ch, CURLOPT_POSTFIELDS, [
+            'query' => $query,
+            'variables[file]' => $variables['file']
+        ]);
+
+        
+        // Execute the cURL request
+        $response = curl_exec($ch);
+        
+        // Check for errors
+        if (curl_errno($ch)) {
+            $error_msg = curl_error($ch);
+            return $error_msg;
+        } else {
+            return $response;
+        }
+        
+        curl_close($ch);
+
+        
+    }
+
+    public function createItem(Request $request) { 
+
+        $payload = $request->all();
+
+        echo '<pre>';
+        print_r($payload);
+        echo '[Line]:     ' . __LINE__ . "\n";
+        echo '[Function]: ' . __FUNCTION__ . "\n";
+        echo '[Class]:    ' . (__CLASS__ ? __CLASS__ : 'N/A') . "\n";
+        echo '[Method]:   ' . (__METHOD__ ? __METHOD__ : 'N/A') . "\n";
+        echo '[File]:     ' . __FILE__ . "\n";
+        die;
+        
+        
     }
 
 }

--- a/app/Http/Controllers/Incorpify/DashboardController.php
+++ b/app/Http/Controllers/Incorpify/DashboardController.php
@@ -214,7 +214,7 @@ class DashboardController extends Controller
                   id
                   body
                 }
-            }}';        
+            }}';
         } else {
             $query = 'mutation {
                 create_update(item_id: '.$payload['item_id'].' body: "'.$payload['text_body'].'") {
@@ -225,6 +225,49 @@ class DashboardController extends Controller
         }
 
         //run the prepared graphQL query
+        return $this->_getMondayData($query);
+    }
+
+    public function updateReplyOrLike(Request $request){
+
+        $payload = $request->json()->all();
+
+        //validate the request
+        $validator = Validator::make($request->all(), [
+            'mode' => 'required|in:like,reply',
+            'update_id' => 'required',
+            'text_body' => $request->mode == 'reply' ? 'required_if:mode,reply' : '',
+            'item_id' => $request->mode == 'reply' ? 'required_if:mode,reply' : '',
+        ]);
+
+        // Custom error messages
+        $validator->setAttributeNames([
+            'mode' => 'Mode',
+            'update_id' => 'Update ID',
+            'item_id' => 'Item ID',
+            'text_body' => 'Text Body',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        //preparing query
+        $query = "";
+        if($payload['mode']=='like'){
+            $query = 'mutation {
+                like_update (update_id: '.$payload['update_id'].') {
+                  id
+                }
+            }';
+        } else {
+            $query = 'mutation {
+                create_update(item_id : '.$payload['item_id'].' parent_id:'.$payload['update_id'].' body: "'.$payload['text_body'].'") {
+                  id
+                }
+            }';
+        }
+
         return $this->_getMondayData($query);
     }
 

--- a/app/Http/Controllers/Incorpify/DashboardController.php
+++ b/app/Http/Controllers/Incorpify/DashboardController.php
@@ -294,29 +294,51 @@ class DashboardController extends Controller
 
         //search the subitems of the items by email address
         $column_id = "contact_email";
-        $status_id = "dropdown";
+        $description = "text";
+        $required_action = "text2";
+        $assignee = "dropdown7";
+        $overall_status = "overall_status";
+
         $query = '{
             boards(ids: 1873211678) {
               items_page(
                 query_params: {rules: [{column_id: "'.$column_id.'", compare_value: ["'.$payload['email'].'"], operator: contains_text}]}
               ) {
                 items {
-                  id
-                  name
-                  subitems {
-                    name
                     id
-                    created_at
-                    updated_at
-                    column_values(ids: "'.$status_id.'"){
-                      id text
+                    name
+                    subitems {
+                      name
+                      id
+                      created_at
+                      updated_at
+                      column_values(ids: ["'.$description.'", "'.$required_action.'", "'.$assignee.'", "'.$overall_status.'"]) {
+                        id
+                        text
+                     }
+                       updates {
+                        id
+                        text_body
+                        
+                        replies {
+                          id text_body
+                        }
+                     }
+                    
+                    assets {
+                      id
+                      url
+                    }
                     }
                   }
-                }
               }
             }
           }
         ';
+
+        // echo '<pre>';
+        //  print_r($query);
+        //  die;
         
         
         $response = $this->_getMondayData($query);

--- a/app/Traits/MondayApis.php
+++ b/app/Traits/MondayApis.php
@@ -64,33 +64,6 @@ trait MondayApis
         return ['status_code' => $status_code, 'response' => json_decode($response, true), 'errors' => $curl_errors];
     }
 
-    public function _mondayFileUpload ($post_params){
-
-        $curl = curl_init();
-        curl_setopt_array($curl, array(
-        CURLOPT_URL => $this->baseUrl,
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_ENCODING => '',
-        CURLOPT_MAXREDIRS => 30,
-        CURLOPT_TIMEOUT => 30,
-        CURLOPT_FOLLOWLOCATION => true,
-        CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-        CURLOPT_CUSTOMREQUEST => 'POST',
-        // CURLOPT_POSTFIELDS =>json_encode($post_params),
-        CURLOPT_POSTFIELDS =>'{"query":'.json_encode($post_params).'}',
-        CURLOPT_HTTPHEADER => array(
-            'Authorization: Bearer '. env('MONDAY_API_KEY'),
-            'Content-Type: application/json',
-        ),
-        ));
-
-        $response = curl_exec($curl);
-        curl_close($curl);
-        $status_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        $curl_errors = curl_error($curl);
-        return ['status_code' => $status_code, 'response' => json_decode($response, true), 'errors' => $curl_errors];
-    }
-
     public function verifyToken() {
         return response()->json(auth()->user());
     }

--- a/app/Traits/MondayApis.php
+++ b/app/Traits/MondayApis.php
@@ -64,6 +64,33 @@ trait MondayApis
         return ['status_code' => $status_code, 'response' => json_decode($response, true), 'errors' => $curl_errors];
     }
 
+    public function _mondayFileUpload ($post_params){
+
+        $curl = curl_init();
+        curl_setopt_array($curl, array(
+        CURLOPT_URL => $this->baseUrl,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_ENCODING => '',
+        CURLOPT_MAXREDIRS => 30,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+        CURLOPT_CUSTOMREQUEST => 'POST',
+        // CURLOPT_POSTFIELDS =>json_encode($post_params),
+        CURLOPT_POSTFIELDS =>'{"query":'.json_encode($post_params).'}',
+        CURLOPT_HTTPHEADER => array(
+            'Authorization: Bearer '. env('MONDAY_API_KEY'),
+            'Content-Type: application/json',
+        ),
+        ));
+
+        $response = curl_exec($curl);
+        curl_close($curl);
+        $status_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $curl_errors = curl_error($curl);
+        return ['status_code' => $status_code, 'response' => json_decode($response, true), 'errors' => $curl_errors];
+    }
+
     public function verifyToken() {
         return response()->json(auth()->user());
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,6 +114,7 @@ Route::group(['prefix' => "incorpify", "middleware" => ["auth:api"]], function (
     Route::get('/incorpifyById/{id}', [IncorpifyDashboard::class, 'incorpifyById'])->name('incorpify.incorpifyById');
     Route::post('/update', [IncorpifyDashboard::class, 'update'])->name('incorpify.update');
     Route::post('/updateReplyOrLike', [IncorpifyDashboard::class, 'updateReplyOrLike'])->name('incorpify.updateReplyOrLike');
+    Route::post('/uploadFiles', [IncorpifyDashboard::class, 'uploadFiles'])->name('incorpify.uploadFiles');
     Route::post('/getSubItemByEmail', [IncorpifyDashboard::class, 'getSubItemByEmail'])->name('incorpify.getSubItemByEmail');
     Route::get('/profile', [IncorpifyDashboard::class, 'profile'])->name('incorpify.profile');
     Route::get('/refreshToken', [IncorpifyDashboard::class, 'refreshToken'])->name('incorpify.refreshToken');

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,6 +115,7 @@ Route::group(['prefix' => "incorpify", "middleware" => ["auth:api"]], function (
     Route::post('/update', [IncorpifyDashboard::class, 'update'])->name('incorpify.update');
     Route::post('/updateReplyOrLike', [IncorpifyDashboard::class, 'updateReplyOrLike'])->name('incorpify.updateReplyOrLike');
     Route::post('/uploadFiles', [IncorpifyDashboard::class, 'uploadFiles'])->name('incorpify.uploadFiles');
+    Route::post('/createItem', [IncorpifyDashboard::class, 'createItem'])->name('incorpify.createItem');
     Route::post('/getSubItemByEmail', [IncorpifyDashboard::class, 'getSubItemByEmail'])->name('incorpify.getSubItemByEmail');
     Route::get('/profile', [IncorpifyDashboard::class, 'profile'])->name('incorpify.profile');
     Route::get('/refreshToken', [IncorpifyDashboard::class, 'refreshToken'])->name('incorpify.refreshToken');

--- a/routes/web.php
+++ b/routes/web.php
@@ -111,7 +111,8 @@ Route::group(['prefix' => "onboardify", 'middleware' => ['web', 'setSession']], 
 
 Route::group(['prefix' => "incorpify", "middleware" => ["auth:api"]], function () {
     Route::get('/', [IncorpifyDashboard::class, 'dashboard'])->name('incorpify.dashboard');
-    Route::get('/{id}', [IncorpifyDashboard::class, 'incorpifyById'])->name('incorpify.incorpifyById');
+    Route::get('/incorpifyById/{id}', [IncorpifyDashboard::class, 'incorpifyById'])->name('incorpify.incorpifyById');
+    Route::post('/update', [IncorpifyDashboard::class, 'update'])->name('incorpify.update');
     Route::get('/profile', [IncorpifyDashboard::class, 'profile'])->name('incorpify.profile');
     Route::get('/refreshToken', [IncorpifyDashboard::class, 'refreshToken'])->name('incorpify.refreshToken');
     Route::get('/logout', [IncorpifyDashboard::class, 'logout'])->name('incorpify.logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -114,6 +114,7 @@ Route::group(['prefix' => "incorpify", "middleware" => ["auth:api"]], function (
     Route::get('/incorpifyById/{id}', [IncorpifyDashboard::class, 'incorpifyById'])->name('incorpify.incorpifyById');
     Route::post('/update', [IncorpifyDashboard::class, 'update'])->name('incorpify.update');
     Route::post('/updateReplyOrLike', [IncorpifyDashboard::class, 'updateReplyOrLike'])->name('incorpify.updateReplyOrLike');
+    Route::post('/getSubItemByEmail', [IncorpifyDashboard::class, 'getSubItemByEmail'])->name('incorpify.getSubItemByEmail');
     Route::get('/profile', [IncorpifyDashboard::class, 'profile'])->name('incorpify.profile');
     Route::get('/refreshToken', [IncorpifyDashboard::class, 'refreshToken'])->name('incorpify.refreshToken');
     Route::get('/logout', [IncorpifyDashboard::class, 'logout'])->name('incorpify.logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -113,6 +113,7 @@ Route::group(['prefix' => "incorpify", "middleware" => ["auth:api"]], function (
     Route::get('/', [IncorpifyDashboard::class, 'dashboard'])->name('incorpify.dashboard');
     Route::get('/incorpifyById/{id}', [IncorpifyDashboard::class, 'incorpifyById'])->name('incorpify.incorpifyById');
     Route::post('/update', [IncorpifyDashboard::class, 'update'])->name('incorpify.update');
+    Route::post('/updateReplyOrLike', [IncorpifyDashboard::class, 'updateReplyOrLike'])->name('incorpify.updateReplyOrLike');
     Route::get('/profile', [IncorpifyDashboard::class, 'profile'])->name('incorpify.profile');
     Route::get('/refreshToken', [IncorpifyDashboard::class, 'refreshToken'])->name('incorpify.refreshToken');
     Route::get('/logout', [IncorpifyDashboard::class, 'logout'])->name('incorpify.logout');


### PR DESCRIPTION
## Description

This pull request introduces a series of new APIs leveraging monday.com APIs to perform the following operations:

1. **Update [done]** - An API endpoint to handle updates.
2. **Reply [done]** - An API endpoint to manage replies.
3. **Like [done]** - An API endpoint to manage likes.
4. **Document Upload [done]** - An API endpoint to handle document uploads.
5. **Item Record Create [done]** - An API endpoint to create new item records.

These additions enhance our integration capabilities with monday.com, providing a more robust and comprehensive set of functionalities for our users.

## Checklist

- [x] Implemented the Update API
- [x] Implemented the Reply API
- [x] Implemented the Like API
- [ ] Implemented the Document Upload API
- [x] Implemented the Item Record Create API
- [x] Tested each API endpoint for functionality and performance
- [x] Updated the documentation to reflect the new APIs

Please review the changes and provide feedback. Thank you!
